### PR TITLE
Changes `gem update` to `gem install`

### DIFF
--- a/jenkins/run-tests.sh
+++ b/jenkins/run-tests.sh
@@ -443,7 +443,7 @@ EOF
 fi
 
 # Ensure we have the newest selenium-webdriver
-gem update selenium-webdriver
+gem install selenium-webdriver
 
 # If DISPLAY is unset, there is no way selenium/firefox could work
 if [ -n "${DISPLAY}" ]


### PR DESCRIPTION
So that selenium-webdriver is made available to the sanity check even if it was not installed at all yet.
